### PR TITLE
Fixed issue where passing in isSwipeable={false} wasn't working

### DIFF
--- a/src/components/SplitterSide.jsx
+++ b/src/components/SplitterSide.jsx
@@ -41,7 +41,7 @@ class SplitterSide extends BasicComponent {
     var {...props} = this.props;
 
     props.collapse = this.props.isCollapsed ? 'collapse' : 'false';
-    props.swipeable = this.props.isSwipeable ? 'swipeable' : 'false';
+    props.swipeable = this.props.isSwipeable ? 'swipeable' : null;
 
     Util.convert(props, 'width', {fun: Util.sizeConverter});
     Util.convert(props, 'animation');


### PR DESCRIPTION
Setting prop "swipeable" to string 'false' (or even bool false) when isSwipeable is not truthy still adds it to the element like this `<ons-splitter-side swipeable="false">`. Setting the swipeable prop to null keeps it from being added to `<ons-splitter-side>` which fixes the problem.