### PR TITLE
Fixed input performance issue on cordova android

### DIFF
--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -40,15 +40,6 @@ class Input extends BasicComponent {
   }
 
   componentWillReceiveProps(props) {
-    var node = ReactDOM.findDOMNode(this);
-
-    if (typeof props.value !== 'undefined') {
-      node.value = props.value;
-    }
-
-    if (typeof props.checked !== 'undefined') {
-      node.checked = props.checked;
-    }
   }
 
   render() {


### PR DESCRIPTION
Setting the node.value explicitly was causing poor performance on cordova android build when using controlled component with onChange.

- Text input was slow when typing words fast

- Would only delete one character if you held down the backspace key

These lines could just be removed because attributes are transferred to `<ons-input>` in the render method anyway.