### PR TITLE
Trigger componentWillReceiveProps on componentDidMount

### DIFF
--- a/src/components/SplitterSide.jsx
+++ b/src/components/SplitterSide.jsx
@@ -75,6 +75,7 @@ class SplitterSide extends BasicComponent {
   componentDidMount() {
     super.componentDidMount();
     this.node = ReactDOM.findDOMNode(this);
+    this.componentWillReceiveProps(this.props);
 
     this.node.addEventListener('postopen', this.props.onOpen);
     this.node.addEventListener('postclose', this.props.onClose);


### PR DESCRIPTION
Closes #42

To ensure that the `isOpen` value is taken into account when mounted we need to trigger `componentWillReceiveProps` manually.

https://facebook.github.io/react/tips/componentWillReceiveProps-not-triggered-after-mounting.html