### PR TITLE
feat(tabbar): use index instead of functions fixes #46

### DIFF
--- a/demo/examples/Tabbar.js
+++ b/demo/examples/Tabbar.js
@@ -4,33 +4,45 @@ import {Tabbar, Tab, Page, Button} from '../../src/index.js';
 import MyToolbar from './MyToolbar';
 
 class TabPage extends React.Component {
-  switchTab() {
-    const index = this.props.tabbar.getActiveTabIndex();
-    this.props.tabbar.setActiveTab((index + 1) % 2);
-  }
-
   render() {
     return (
       <Page renderToolbar={() => <MyToolbar title={this.props.title} />} >
-        {this.props.active ?
-          <p>This is the <strong>{this.props.title}</strong> page.</p> : null}
-
-        <Button onClick={this.switchTab.bind(this)}>Go to the other tab</Button>
+        {this.props.active
+          ? <p>This is the <strong>{this.props.title}</strong> page.</p>
+          : null}
+        <Button onClick={this.props.switchTab}>Go to the other tab</Button>
       </Page>
     );
   }
 }
 
 export default class extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      index: 0
+    };
+    this.renderTabs = this.renderTabs.bind(this);
+  }
+
   renderTabs(activeIndex, tabbar) {
+    console.log('index : ' , activeIndex);
     return [
       {
-        content: <TabPage title="Home" active={activeIndex === 0} tabbar={tabbar} />,
-        tab: <Tab label="Home" icon="md-home" />
+        content: <TabPage switchTab={() => { this.setState({index: 1}); }}
+        title='Home' active={activeIndex == 0} tabbar={tabbar} />,
+        tab: <Tab
+          onClick={() => console.log('click home')}
+          label='Home'
+          icon='md-home' />
       },
       {
-        content: <TabPage title="Settings" active={activeIndex === 1} tabbar={tabbar} />,
-        tab: <Tab label="Settings" icon="md-settings" />
+        content: <TabPage
+          switchTab={() => { this.setState({index: 0}); }}
+
+        title='Settings' active={activeIndex == 1} tabbar={tabbar} />,
+        tab: <Tab onClick={() => console.log('click setting')} label='Settings' icon='md-settings' />
       }
     ];
   }
@@ -39,8 +51,13 @@ export default class extends React.Component {
     return (
       <Page>
         <Tabbar
-          initialIndex={1}
-          onPreChange={() => console.log('preChange')}
+          index={this.state.index}
+          onPreChange={(event) =>
+            {
+              this.setState({index: event.index});
+              console.log('preChange', event.index);
+            }
+          }
           onPostChange={() => console.log('postChange')}
           onReactive={() => console.log('postChange')}
           position='bottom'

--- a/src/components/Tabbar.jsx
+++ b/src/components/Tabbar.jsx
@@ -13,10 +13,11 @@ import Util from './Util.js';
 
   <Page>
     <Tabbar
-      onPreChange={() => console.log('preChange')}
+      onPreChange={({index}) => this.setState(index)}
       onPostChange={() => console.log('postChange')}
       onReactive={() => console.log('postChange')}
       position='bottom'
+      index={this.state.index}
       renderTabs={(activeIndex, tabbar) => [
         {
           content: <TabPage title="Home" active={activeIndex === 0} tabbar={tabbar} />,
@@ -33,18 +34,10 @@ import Util from './Util.js';
 
 class Tabbar extends BasicComponent {
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      activeIndex: props.initialIndex || 0
-    };
-  }
-
   componentDidMount() {
     super.componentDidMount();
     const node = this.refs.tabbar;
     CustomElements.upgrade(node);
-    node.addEventListener('prechange', this.handleChange.bind(this));
     node.addEventListener('prechange', this.props.onPreChange);
     node.addEventListener('postchange', this.props.onPostChange);
     node.addEventListener('reactive', this.props.onReactive);
@@ -52,58 +45,26 @@ class Tabbar extends BasicComponent {
 
   componentWillUnmount() {
     const node = this.refs.tabbar;
-    node.removeEventListener('prechange', this.handleChange);
     node.removeEventListener('prechange', this.props.onPreChange);
     node.removeEventListener('postchange', this.props.onPostChange);
     node.removeEventListener('reactive', this.props.onReactive);
   }
 
-  handleChange(event) {
-    this.setState({activeIndex: event.index});
-  }
-
-  /**
-   * @method setActiveTab
-   * @signature setActiveTab(index, options)
-   * @param {Number} index
-   *   [en]Tab index.[/en]
-   *   [ja]タブのインデックスを指定します。[/ja]
-   * @param {Object} [options]
-   *   [en]Parameter object.[/en]
-   *   [ja]オプションを指定するオブジェクト。[/ja]
-   * @param {Boolean} [options.keepPage]
-   *   [en]If true the page will not be changed.[/en]
-   *   [ja]タブバーが現在表示しているpageを変えない場合にはtrueを指定します。[/ja]
-   * @param {String} [options.animation]
-   *   [en]Animation name. Available animations are `"fade"`, `"slide"` and `"none"`.[/en]
-   *   [ja]アニメーション名を指定します。`"fade"`、`"slide"`、`"none"`のいずれかを指定できます。[/ja]
-   * @description
-   *   [en]Show specified tab page. Animations and other options can be specified by the second parameter.[/en]
-   *   [ja]指定したインデックスのタブを表示します。アニメーションなどのオプションを指定できます。[/ja]
-   * @return {Promise}
-   *   [en]Resolves to the new page element.[/en]
-   *   [ja][/ja]
-   */
-  setActiveTab(index, options) {
-    this.refs.tabbar.setActiveTab(index, options);
-  }
-
-  /**
-   * @method getActiveTabIndex
-   * @signature getActiveTabIndex()
-   * @return {Number}
-   *   [en]The index of the currently active tab.[/en]
-   *   [ja]現在アクティブになっているタブのインデックスを返します。[/ja]
-   * @description
-   *   [en]Returns tab index on current active tab. If active tab is not found, returns -1.[/en]
-   *   [ja]現在アクティブになっているタブのインデックスを返します。現在アクティブなタブがない場合には-1を返します。[/ja]
-   */
-  getActiveTabIndex() {
-    return this.refs.tabbar.getActiveTabIndex();
+  componentDidUpdate(prevProps) {
+    super.componentDidUpdate(prevProps);
+    if (prevProps.index !== this.props.index) {
+      this.refs.tabbar.setActiveTab(this.props.index);
+    }
   }
 
   render() {
-    const tabs = this.props.renderTabs(this.state.activeIndex, this);
+    const tabs = this.props.renderTabs(this.props.index, this);
+
+    if (!this.tabPages) {
+      this.tabPages = tabs.map((tab) => tab.content);
+    } else {
+      this.tabPages[this.props.index] = tabs[this.props.index].content;
+    }
 
     var {...others} = this.props;
 
@@ -114,9 +75,9 @@ class Tabbar extends BasicComponent {
     Util.convert(others, 'animationOptions', {fun: Util.animationOptionsConverter, newName: 'animation-options'});
 
     return (
-      <ons-tabbar {...this.props} ref='tabbar' activeIndex={this.state.activeIndex} _compiled='true'>
+      <ons-tabbar {...this.props} ref='tabbar' activeIndex={this.props.index} _compiled='true'>
         <div no-status-bar-fill className={'ons-tab-bar__content tab-bar__content' + (this.props.position === 'top' ? ' tab-bar--top__content' : '')}>
-          {tabs.map((tab) => tab.content)}
+          {this.tabPages}
         </div>
         <div className={'tab-bar ons-tab-bar__footer ons-tabbar-inner' + (this.props.position === 'top' ? ' tab-bar--top' : '')}>
           {tabs.map((tab) => tab.tab)}
@@ -124,17 +85,18 @@ class Tabbar extends BasicComponent {
       </ons-tabbar>
     );
   }
-};
+}
 
 Tabbar.propTypes = {
   /**
-   * @name initialIndex
+   * @name index
    * @type number
+   * @required
    * @description
-   *  [en] The index of the first tab to show.[/en]
+   *  [en] The index of the tab to highlight.[/en]
    *  [jp] [/jp]
    */
-  initialIndex: React.PropTypes.number,
+  index: React.PropTypes.number.isRequired,
 
   /**
    * @name renderTabs
@@ -202,7 +164,7 @@ Tabbar.propTypes = {
 };
 
 Tabbar.defaultProps = {
-  initialIndex: 0
+  index: 0
 };
 
 export default Tabbar;


### PR DESCRIPTION
This will add index property for the tabbar. We will only render the new pages and keep the old ones, otherwise this may cause flickering. 
@argelius your opinion would be appreciated. I think we might also update the tutorials/docs.