### PR TITLE
Apply modifier to page elements

### DIFF
--- a/src/components/Page.jsx
+++ b/src/components/Page.jsx
@@ -37,13 +37,25 @@ class Page extends BasicComponent {
 
     const modal = this.props.renderModal(this);
 
-    return <ons-page {...this.props} _compiled='true' >
+    const modifier = this.props.modifier;
+    let backgroundModifierClass = null;
+    let contentModifierClass = null;
+    let extraModifierClass = null;
+    
+    if (modifier) {
+      const pageClass = `page--${modifier}`;
+      backgroundModifierClass = `${pageClass}__background`;
+      contentModifierClass = `${pageClass}__content`;
+      extraModifierClass = `${pageClass}__extra`;
+    }
+    
+    return <ons-page {...this.props} _compiled='true'>
         {toolbar}
-        <div className='page__background'> </div>
-        <div className='page__content'>
+        <div className={`page__background ${backgroundModifierClass}`}> </div>
+        <div className={`page__content ${contentModifierClass}`}>
           {this.props.children}
         </div>
-        <div className='page__extra' style={{zIndex: 10001}}>
+        <div className={`page__extra ${extraModifierClass}`} style={{zIndex: 10001}}>
           {modal}
         </div>
         {bottomToolbar}

--- a/src/components/Page.jsx
+++ b/src/components/Page.jsx
@@ -41,14 +41,14 @@ class Page extends BasicComponent {
     let backgroundModifierClass = null;
     let contentModifierClass = null;
     let extraModifierClass = null;
-    
+
     if (modifier) {
       const pageClass = `page--${modifier}`;
       backgroundModifierClass = `${pageClass}__background`;
       contentModifierClass = `${pageClass}__content`;
       extraModifierClass = `${pageClass}__extra`;
     }
-    
+
     return <ons-page {...this.props} _compiled='true'>
         {toolbar}
         <div className={`page__background ${backgroundModifierClass}`}> </div>


### PR DESCRIPTION
Currently, when passing a modifier to the Page component it doesn't get applied to the inner elements like content or background. This is a different behaviour from the standalone version of OnsenUI 2. This pull request fixes this inconsistency.