### PR TITLE
Get rid of global onsen object

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,7 +6,6 @@ module.exports = function(config) {
     singleRun: true, // just run once by default
     frameworks: [ 'mocha', 'chai' ], // use the mocha test framework
     files: [
-      'node_modules/onsenui/js/onsenui.js',
       'node_modules/onsenui/css/onsenui.css',
       'node_modules/onsenui/css/onsen-css-components.css',
       'tests.webpack.js' // just load this file
@@ -17,9 +16,11 @@ module.exports = function(config) {
     reporters: [ 'dots' ], // report results in this format
     webpack: { // kind of a copy of your webpack config
       devtool: 'inline-source-map', // just do inline source maps instead of the default
+
       module: {
         loaders: [
           { test: /\.js$/, loader: 'babel-loader',
+            exclude: [/node_modules/, /onsenui\.js/],
             query: { presets: ['es2015', 'react'] }
           }
         ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,12 +25,14 @@ export default {
   external: [
     'react',
     'react-dom/server',
-    'react-dom'
+    'react-dom',
+    'onsenui'
   ],
   globals: {
     'react': 'React',
     'react-dom': 'ReactDOM',
-    'react-dom/server': 'ReactDOMServer'
+    'react-dom/server': 'ReactDOMServer',
+    'onsenui': 'ons'
   },
   format: 'umd',
   moduleName: 'Ons',

--- a/src/components/BasicComponent.jsx
+++ b/src/components/BasicComponent.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import ons from 'onsenui';
+
 class BasicComponent extends React.Component {
   constructor(props) {
     super(props);
@@ -20,11 +22,11 @@ class BasicComponent extends React.Component {
       node.className = node.className.trim() + this.lastClass;
     }
 
-    if (!window._superSecretOns) {
+    if (!ons) {
       throw new Error("react-onsenui requires `onsenui`, make sure you are loading it with `import onsenui` or `require('onsenui')` before using the components");
     }
 
-    window._superSecretOns._autoStyle.prepare(node);
+    ons._autoStyle.prepare(node);
   }
 
   componentDidMount() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = {
         loader: 'style!css'
       },
       { test: /\.js$|\.jsx$/,
-        exclude: [/node_modules/, /onsenui.js/],
+        exclude: [/node_modules/, /onsenui\.js/],
         loaders: [ 'react-hot',
           'babel?' + JSON.stringify({presets: ['stage-2', 'es2015', 'react']})
         ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 var webpack = require('webpack');
+var path = require('path');
 
 module.exports = {
   devtool: 'eval-source-map',
@@ -12,7 +13,6 @@ module.exports = {
     path: __dirname + '/demo',
     filename: "bundle.js"
   },
-
   devServer: {
     // contentBase
     colors: true,
@@ -20,6 +20,11 @@ module.exports = {
     inline: false,
     port: 9000,
     hot: true
+  },
+  resolve: {
+    alias: {
+      'onsenui': path.join(__dirname, 'OnsenUI/build/js/onsenui.js')
+    }
   },
   module: {
     loaders: [


### PR DESCRIPTION
@philolo1 This gets rid of the global Onsen variable. Should work both when using Webpack/browserify or when loading with script tags.