### PR TITLE
#94 properly update child pages in Navigator

### DIFF
--- a/src/components/BasicComponent.jsx
+++ b/src/components/BasicComponent.jsx
@@ -4,8 +4,8 @@ import ReactDOM from 'react-dom';
 import ons from 'onsenui';
 
 class BasicComponent extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor(...args) {
+    super(...args);
     this.updateClasses = this.updateClasses.bind(this);
   }
 

--- a/src/components/LazyList.jsx
+++ b/src/components/LazyList.jsx
@@ -41,8 +41,8 @@ import BasicComponent from './BasicComponent.jsx';
 }
  */
 class LazyList extends BasicComponent {
-  constructor(props) {
-    super(props);
+  constructor(...args) {
+    super(...args);
     this.state = {children: []};
     this.update = this.update.bind(this);
   }

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -29,8 +29,8 @@ import BasicComponent from './BasicComponent.jsx';
   </Page>
  */
 class Modal extends BasicComponent {
-  constructor(props, context) {
-    super(props, context);
+  constructor(...args) {
+    super(...args);
     this.node = null;
   }
 

--- a/src/components/Navigator.jsx
+++ b/src/components/Navigator.jsx
@@ -24,8 +24,8 @@ import Util from './Util.js';
  }
  */
 class Navigator extends BasicComponent {
-  constructor(props) {
-    super(props);
+  constructor(...args) {
+    super(...args);
     this.pages = [];
     this.state = { };
     this._prePush = this._prePush.bind(this);
@@ -271,12 +271,13 @@ class Navigator extends BasicComponent {
   }
 
   render() {
-    var {...others} = this.props;
+    const {...others} = this.props;
     Util.convert(others, 'animationOptions', {fun: Util.animationOptionsConverter, newName: 'animation-options'});
+    const pages = this.routes ? this.routes.map((route) => this.props.renderPage(route, this)) : null;
 
     return (
       <ons-navigator {...others} ref='navi'>
-        {this.pages}
+        {pages}
       </ons-navigator>
     );
   }

--- a/src/components/Navigator.jsx
+++ b/src/components/Navigator.jsx
@@ -191,12 +191,13 @@ class Navigator extends BasicComponent {
     const update = () => {
       return new Promise((resolve) => {
         this.pages.pop();
+        this.routes.pop();
+
         this.forceUpdate(resolve);
       });
     };
 
-    return this.refs.navi._popPage(options, update)
-      .then(() => this.routes.pop());
+    return this.refs.navi._popPage(options, update);
   }
 
   _prePop(event) {


### PR DESCRIPTION
This should solve the issue described in #94. Also, I've updated the constructors to pass all parameters to the parent constructor. Components usually have more than one constructor argument and those should be passed properly to the parent to prevent potential side effects in future versions of React.